### PR TITLE
Yaml option for path (#25)

### DIFF
--- a/scripts/deploying.js
+++ b/scripts/deploying.js
@@ -102,6 +102,7 @@ $(document).ready(() => {
       settings.runApexTests = 'false';
       settings.scratchOrgDef = 'config/project-scratch-def.json';
       settings.showScratchOrgUrl = 'true';
+      settings.openPath = '';
 
     },
     success: (yamlFileDataResponse) => {
@@ -123,7 +124,8 @@ $(document).ready(() => {
       settings.runApexTests = doc['run-apex-tests'];
       settings.scratchOrgDef = doc['scratch-org-def'];
       settings.showScratchOrgUrl = doc['show-scratch-org-url'];
-
+      settings.openPath = doc['open-path'];
+      
       const dataPlanCount = doc['data-plans'].length;
 
       if (dataPlanCount > 0) {

--- a/views/pages/notdevhub.ejs
+++ b/views/pages/notdevhub.ejs
@@ -10,7 +10,7 @@
       </div>
     </div>
 
-    <p class="slds-m-bottom_medium">Consequently, you cannot currently use <strong>Deploy to Salesforce DX</strong> to create a stratch org from a Github repo. You can learn more about the Dev Hub  <a href="https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_enable_devhub.htm" target="_blank">here</a>.</p>
+    <p class="slds-m-bottom_medium">Consequently, you cannot currently use <strong>Deploy to Salesforce DX</strong> to create a scratch org from a Github repo. You can learn more about the Dev Hub  <a href="https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_enable_devhub.htm" target="_blank">here</a>.</p>
 
     <p class="slds-m-bottom_medium">To try this out, you have two options:</p>
 

--- a/views/pages/repo.ejs
+++ b/views/pages/repo.ejs
@@ -18,6 +18,7 @@
   run-apex-tests: true
   delete-scratch-org: false
   show-scratch-org-url: true
+  open-path: c/YourCustomApp.app
   data-plans:
     - ./data/YourCustomObject1__c-plan.json
     - ./data/YourCustomObject2__c-plan.json

--- a/worker.js
+++ b/worker.js
@@ -178,6 +178,10 @@ async.whilst(
 
         settings.testScript = `${settings.startingDirectory}cd ${settings.directory};export FORCE_SHOW_SPINNER=;sfdx force:apex:test:run -r human --json | jq -r .result | jq -r .summary | jq -r .outcome`;
         settings.urlScript = `${settings.startingDirectory}cd ${settings.directory};export FORCE_SHOW_SPINNER=;echo $(sfdx force:org:display --json | jq -r .result.instanceUrl)"/secur/frontdoor.jsp?sid="$(sfdx force:org:display --json | jq -r .result.accessToken)`;
+        // add path if specified in yaml
+        if (settings.openPath) {
+          settings.urlScript += `"&retURL="${settings.openPath}`;
+        }
         settings.scratchOrgUrl = '';
         settings.stderr = '';
         settings.stdout = '';


### PR DESCRIPTION
Added support for path in `yaml` file, the same way it works in the command line with `force:org:open -p`.