### PR TITLE
Fixed Uncaught TypeError when no data plans provided

### DIFF
--- a/scripts/deploying.js
+++ b/scripts/deploying.js
@@ -125,8 +125,8 @@ $(document).ready(() => {
       settings.scratchOrgDef = doc['scratch-org-def'];
       settings.showScratchOrgUrl = doc['show-scratch-org-url'];
       settings.openPath = doc['open-path'];
-      
-      const dataPlanCount = doc['data-plans'].length;
+
+      const dataPlanCount = doc['data-plans'] ? doc['data-plans'].length : 0;
 
       if (dataPlanCount > 0) {
         


### PR DESCRIPTION
Small update: When no data-plans were provided in the salesforcedx.yaml file, an error was thrown in the console: "Uncaught TypeError: Cannot read property 'length' of undefined".